### PR TITLE
Adds back support for window titling

### DIFF
--- a/lua/kitty-runner.lua
+++ b/lua/kitty-runner.lua
@@ -15,7 +15,7 @@ local whole_command
 
 local function open_new_runner()
   loop.spawn('kitty', {
-    args = {'-o', 'allow_remote_control=yes', '--listen-on=' .. Cfg.kitty_port}})
+    args = {'-o', 'allow_remote_control=yes', '--listen-on=' .. Cfg.kitty_port, '--title=' .. Cfg.runner_name}})
   Cfg.runner_is_open = true
 end
 
@@ -113,6 +113,7 @@ function M.setup(cfg_)
   local uuid_handle = io.popen[[uuidgen|sed 's/.*/&/']]
   local uuid = uuid_handle:read("*a")
   uuid_handle:close()
+  Cfg.runner_name = Cfg.runner_name or 'kitty-runner' .. uuid
   Cfg.run_cmd = Cfg.run_cmd or {'send-text'}
   Cfg.kill_cmd = Cfg.kill_cmd or {'close-window'}
   if Cfg.use_keymaps ~= nil then


### PR DESCRIPTION
This adds back support of setting a window title. While this doesn't affect runner matching, it does allow for actions based upon the window title, such as pinning the runner window on a specific display. An example i3 config to put the runner window on the sixth workspace:

```assign [title="^kitty-runner.*"] $ws6```