### PR TITLE
Only read line from uuidgen

### DIFF
--- a/lua/kitty-runner.lua
+++ b/lua/kitty-runner.lua
@@ -111,7 +111,7 @@ end
 function M.setup(cfg_)
   Cfg = cfg_ or {}
   local uuid_handle = io.popen[[uuidgen|sed 's/.*/&/']]
-  local uuid = uuid_handle:read("*a")
+  local uuid = uuid_handle:read("*l")
   uuid_handle:close()
   Cfg.runner_name = Cfg.runner_name or 'kitty-runner' .. uuid
   Cfg.run_cmd = Cfg.run_cmd or {'send-text'}


### PR DESCRIPTION
Changes from reading all to line. Mostly cosmetic however `*all` includes newline and EOL while `*line` only grabs the expected output from `uuidgen`.