### PR TITLE
Make it possible to run in 'window' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,33 @@ require("kitty-runner").setup({
   use_keymaps = true,
   -- the port used to communicate with the kitty terminal:
   kitty_port = "unix:/tmp/kitty-" .. uuid,
+  -- the type of window that kitty will create:
+  -- - os-window = a new window
+  -- - window = a new split within the current window (see below)
+  -- - More info: https://sw.kovidgoyal.net/kitty/glossary/#term-os_window
+  mode = "os-window"
 })
+```
+
+### Window Mode
+
+By default `kitty-runner` will open OS level windows, if you would like to open "kitty windows" or splits inside your current window you can configure like so:
+
+
+```lua
+local opts = require("kitty-runner.config").window_config
+require("kitty-runner").setup(opts)
+```
+
+...which will setup the following:
+
+```lua
+{
+  runner_name = "kitty-runner-" .. uuid,
+  run_cmd = { "send-text", "--match=title:" .. "kitty-runner-" .. uuid },
+  kill_cmd = { "close-window", "--match=title:" .. "kitty-runner-" .. uuid },
+  use_keymaps = true,
+  kitty_port = "unix:/tmp/kitty",
+  mode = "window"
+}
 ```

--- a/lua/kitty-runner/config.lua
+++ b/lua/kitty-runner/config.lua
@@ -4,6 +4,7 @@
 
 local cmd = vim.cmd
 local nvim_set_keymap = vim.api.nvim_set_keymap
+local M = {}
 
 -- get uuid
 local function get_uuid()
@@ -12,6 +13,8 @@ local function get_uuid()
 	uuid_handle:close()
 	return uuid
 end
+
+M.uuid = get_uuid
 
 local uuid = get_uuid()
 
@@ -22,9 +25,21 @@ local default_config = {
 	kill_cmd = { "close-window" },
 	use_keymaps = true,
 	kitty_port = "unix:/tmp/kitty-" .. uuid,
+	mode = "os-window"
 }
 
-local M = vim.deepcopy(default_config)
+local window_config = {
+	runner_name = "kitty-runner-" .. uuid,
+	run_cmd = { "send-text", "--match=title:" .. "kitty-runner-" .. uuid },
+	kill_cmd = { "close-window", "--match=title:" .. "kitty-runner-" .. uuid },
+	use_keymaps = true,
+	kitty_port = "unix:/tmp/kitty",
+	mode = "window"
+}
+
+M = vim.deepcopy(default_config)
+M.default_config = default_config
+M.window_config = window_config
 
 -- configuration update function
 M.update = function(opts)

--- a/lua/kitty-runner/kitty-runner.lua
+++ b/lua/kitty-runner/kitty-runner.lua
@@ -51,15 +51,28 @@ end
 
 function M.open_runner()
 	if runner_is_open == false then
-		loop.spawn("kitty", {
-			args = {
-				"-o",
-				"allow_remote_control=yes",
-				"--listen-on=" .. config["kitty_port"],
-				"--title=" .. config["runner_name"],
-			},
-		})
-		runner_is_open = true
+		if config["mode"] == "os-window" then
+			loop.spawn("kitty", {
+				args = {
+					"-o",
+					"allow_remote_control=yes",
+					"--listen-on=" .. config["kitty_port"],
+					"--title=" .. config["runner_name"],
+				},
+			})
+			runner_is_open = true
+		elseif config["mode"] == "window" then
+			loop.spawn("kitty", {
+				args = {
+					"@",
+					"launch",
+					"--title=" .. config["runner_name"],
+					"--keep-focus",
+					"--cwd=" .. vim.fn.getcwd()
+				},
+			})
+			runner_is_open = true
+		end
 	end
 end
 


### PR DESCRIPTION
By default `kitty-runner` will open OS level windows, This feature should allow people to open "kitty windows" or splits inside the current window. Relates to #6.

Configuration example:

 ```lua
 local opts = require("kitty-runner.config").window_config
 require("kitty-runner").setup(opts)
 ```

 ...which will setup the following:

 ```lua
 {
   runner_name = "kitty-runner-" .. uuid,
   run_cmd = { "send-text", "--match=title:" .. "kitty-runner-" .. uuid },
   kill_cmd = { "close-window", "--match=title:" .. "kitty-runner-" .. uuid },
   use_keymaps = true,
   kitty_port = "unix:/tmp/kitty",
   mode = "window"
 }
 ```