### PR TITLE
Use bracketed paste to escape newlines and tabs properly

### DIFF
--- a/lua/kitty-runner/kitty-runner.lua
+++ b/lua/kitty-runner/kitty-runner.lua
@@ -45,8 +45,8 @@ local function prepare_command(region)
   else
     lines = vim.api.nvim_buf_get_lines(0, region[1] - 1, region[2], true)
   end
-  local command = table.concat(lines, "\r") .. "\r"
-  return command
+  local command = table.concat(lines, "\r")
+  return "\\e[200~" .. command .. "\\e[201~" .. "\r"
 end
 
 function M.open_runner()


### PR DESCRIPTION
Uses escape chars to properly insert multiline strings. This prevents REPLs like `ipython` from modifying the inserted buffer in undefined ways. See: https://github.com/jpalardy/vim-slime/blob/a532203bcd7af7f5e571c07b60bba7287076dc19/doc/vim-slime.txt#L124C2-L124C38